### PR TITLE
Modify: pages/index.tsx 렌더링 방식 변경

### DIFF
--- a/Components/ProductContainer/index.ProductContainer.tsx
+++ b/Components/ProductContainer/index.ProductContainer.tsx
@@ -4,7 +4,7 @@ import { ProductProps } from '../Types/ProductType';
 import style from 'Components/ProductContainer/ProductContainer.module.css';
 
 interface ProductContainerProps {
-  ProductData: ProductProps[];
+  ProductData: ProductProps[] | undefined;
   isItemList?: boolean;
 }
 
@@ -15,11 +15,15 @@ const ProductContainer = ({
   return (
     <>
       <div className={style.PDwarpper}>
-        {ProductData.map((item, index) => (
-          <div className={style.innerContainer} key={index}>
-            <ProductContent ProductData={item} isItemList={isItemList} />
-          </div>
-        ))}
+        {ProductData ? (
+          <>
+            {ProductData.map((item, index) => (
+              <div className={style.innerContainer} key={index}>
+                <ProductContent ProductData={item} isItemList={isItemList} />
+              </div>
+            ))}
+          </>
+        ) : null}
       </div>
     </>
   );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,53 +1,67 @@
-import type { GetServerSideProps, NextPage } from 'next'
-import * as C from "Const/Const";
-import styles from 'styles/Home.module.css'
+import type { GetStaticProps, NextPage } from 'next';
+import * as C from 'Const/Const';
+import styles from 'styles/Home.module.css';
 
 import CategoryContainer from 'Components/CategoryContainer/index.CategoryContainer';
 import ProductContainer from 'Components/ProductContainer/index.ProductContainer';
 import Carousel from 'Components/Carousel/index.Carousel';
 
-import * as H from "Hooks/Hooks";
+import * as H from 'Hooks/Hooks';
 import * as T from 'Types/Types';
 
 import { ProductProps } from 'Components/Types/ProductType';
+import { useEffect, useState, useCallback } from 'react';
 import NavBar from 'Components/Nav/NavBar';
 
 interface HomeProps {
   menuCategory: T.CategoryListType[];
-  productContent: ProductProps[];
-  currentPage:string;
+  currentPage: string;
 }
 
-const Home:NextPage<HomeProps> = ({ currentPage, menuCategory, productContent }) => {
+const Home: NextPage<HomeProps> = ({ currentPage, menuCategory }) => {
+  const [productContent, setProductContent] = useState<
+    ProductProps[] | undefined
+  >();
+  const FetchProductContent = useCallback(async () => {
+    const res = await H.Fetch(`${C.CONITEM_API}/${C.SOON}`);
+    setProductContent(res.conItems);
+  }, []);
+  useEffect(() => {
+    FetchProductContent();
+  }, [FetchProductContent]);
+  console.log(productContent);
   return (
     <>
-    <NavBar/>
-    <div className={styles.container}>
-      <main className={styles.main}>
-        <Carousel/>
-        <CategoryContainer CategoryData={menuCategory} currentPage={currentPage}/>
-        <div className={styles.middleContent}>
-          <span className={styles.contentMessage1}>놓치지 마세요</span>
-          <span className={styles.contentMessage2}>오늘의 땡처리콘!</span>
-        </div>
-        <ProductContainer ProductData={productContent} />
-      </main>
+      <NavBar />
+      <div className={styles.container}>
+        <main className={styles.main}>
+          <Carousel />
+          <CategoryContainer
+            CategoryData={menuCategory}
+            currentPage={currentPage}
+          />
+          <div className={styles.middleContent}>
+            <span className={styles.contentMessage1}>놓치지 마세요</span>
+            <span className={styles.contentMessage2}>오늘의 땡처리콘!</span>
+          </div>
+          {productContent ? (
+            <ProductContainer ProductData={productContent} />
+          ) : null}
+        </main>
 
-      <footer className={styles.footer}></footer>
-    </div>
+        <footer className={styles.footer}></footer>
+      </div>
     </>
   );
 };
 
-export const getServerSideProps: GetServerSideProps = async () => {
+export const getStaticProps: GetStaticProps = async () => {
   const menuCategory = await H.Fetch(C.CONCATEGORY_API);
-  const productContent = await H.Fetch(`${C.CONITEM_API}/${C.SOON}`);
 
   return {
     props: {
       currentPage: 'home',
       menuCategory: menuCategory.conCategory1s,
-      productContent: productContent.conItems,
     },
   };
 };


### PR DESCRIPTION
 ### 변경전 렌더링 방식
- 메뉴 카테고리, 땡처리콘 productContainer  : **SSR**(getServerSideProps 함수 사용)

### 변경 후 렌더링 방식
- 메뉴 카테고리  : **SSR**(getStaticProps 함수 사용)
- 땡처리콘 productContainer : **CSR**

### 변경 이유
- getServerSideProps 사용 시 페이지 이동 속도가 느려지는 문제를 개선하고자 렌더링 방식을 변경하였습니다.
- 쉽게 변하지 않는 데이터인 메뉴카테고리를 getStaticProps를 사용하여 사전 렌더링을 하였습니다.
- 그에 비해 땡처리 콘 ProductContainer 데이터에서는 아이템 유무, 아이템의 가격, 할인율 등 데이터 정보가 빌드 시점 이후 쉽게 바뀔 수 있으므로 CSR을 사용하였습니다.
