### PR TITLE
렌더링 방식 변경

### DIFF
--- a/Components/CategoryContainer/index.CategoryContainer.tsx
+++ b/Components/CategoryContainer/index.CategoryContainer.tsx
@@ -1,19 +1,22 @@
-import style from "Components/CategoryContainer/CategoryContainer.module.css";
-import Category from "Components/Category/index.Category";
-import * as T  from 'Types/Types';
+import style from 'Components/CategoryContainer/CategoryContainer.module.css';
+import Category from 'Components/Category/index.Category';
+import * as T from 'Types/Types';
 
 interface CategoryContainerProps {
-  CategoryData: T.CategoryListType[]
-  currentPage : string;
+  CategoryData: T.CategoryListType[];
+  currentPage: string;
 }
 
-const CategoryContainer = ({CategoryData,currentPage}:CategoryContainerProps) => {
+const CategoryContainer = ({
+  CategoryData,
+  currentPage,
+}: CategoryContainerProps) => {
   return (
     <div className={style.Container}>
-      {CategoryData.map((item: T.CategoryListType,index :number) =>  {
+      {CategoryData.map((item: T.CategoryListType, index: number) => {
         return (
           <div key={index} className={style.innerContainer}>
-            <Category CategoryData={item} currentPage={currentPage}/>
+            <Category CategoryData={item} currentPage={currentPage} />
           </div>
         );
       })}

--- a/pages/brands/[id].tsx
+++ b/pages/brands/[id].tsx
@@ -1,73 +1,96 @@
-import type { NextPage, GetServerSideProps, GetServerSidePropsContext } from 'next'
-import { useRouter } from 'next/router'
-import styles from '/styles/Categories.module.css'
-import * as C from "Const/Const";
-import * as H from "Hooks/Hooks";
+import type {
+  NextPage,
+  GetServerSideProps,
+  GetServerSidePropsContext,
+} from 'next';
+import { useRouter } from 'next/router';
+import styles from '/styles/Categories.module.css';
+import * as C from 'Const/Const';
+import * as H from 'Hooks/Hooks';
 import { useState, useEffect } from 'react';
 import ProductContainer from 'Components/ProductContainer/index.ProductContainer';
 import css from 'styled-jsx/css';
 import NavBar from 'Components/Nav/NavBar';
 
 interface PropsType {
-  allCategors:any,
-  currentPage: string,
-  curruntID: string,
-  BrandList: []
+  allCategors: any;
+  currentPage: string;
+  curruntID: string;
+  BrandList: [];
 }
 
-const Brands = ({ allCategors, currentPage, curruntID, BrandList }: PropsType) => {
-    const [brandsList, setBrandsList] = useState<any[]>([]);
-    const [PH, setPH] = useState<any[]>([]);
-    const [brandProductList, setbrandProductList] = useState([]);
-    const [productInfo, setproductInfo] = useState<any>({});
-    const [containerProps, setContainerProps] = useState<any[]>([]);
-    const [sortMode, setSortMode] = useState('priority')
-    const router = useRouter();
-    useEffect(()=>{
-        (async()=> {
-            for(let idx = 0; idx < allCategors.length; idx ++){
-                if (allCategors[idx].id === 1){
-                    continue;
-                }
-                const APIdata = await H.Fetch(C.CONCATEGORY_API + allCategors[idx].id + C.NESTED);
-                setPH( [...APIdata.conCategory1.conCategory2s] );   
-            }
-        })();
-    }, [])
-    useEffect(()=> {  
-        setBrandsList([...brandsList, ...PH]);
-        const propsidx = brandsList.findIndex(e=> e.id === parseInt(curruntID));
-        const temp = propsidx !== -1? brandsList[propsidx].conItems: [];
-        setbrandProductList(temp);
-    }, [PH])
-    interface productType {id : string}
-    useEffect(()=> {
-        brandProductList.forEach(async (product:productType) => {
-            const APIdata = await H.Fetch(C.CONITEM_API + product.id);
-            setproductInfo(APIdata)
-        })
-    }, [brandProductList]);
-    useEffect(() => {
-        if(productInfo.conItem){
-        const newstate:any = containerProps;
-        newstate.push(productInfo.conItem);
-        setContainerProps(newstate)
-    }}, [productInfo])
-    return (
-      <>
-      <NavBar brandName = {containerProps[0] ? containerProps[0].conCategory2.name : undefined }/>
+const Brands = ({
+  allCategors,
+  currentPage,
+  curruntID,
+  BrandList,
+}: PropsType) => {
+  const [brandsList, setBrandsList] = useState<any[]>([]);
+  const [PH, setPH] = useState<any[]>([]);
+  const [brandProductList, setbrandProductList] = useState([]);
+  const [productInfo, setproductInfo] = useState<any>({});
+  const [containerProps, setContainerProps] = useState<any[]>([]);
+  const [sortMode, setSortMode] = useState('priority');
+  const router = useRouter();
+  useEffect(() => {
+    (async () => {
+      for (let idx = 0; idx < allCategors.length; idx++) {
+        if (allCategors[idx].id === 1) {
+          continue;
+        }
+        const APIdata = await H.Fetch(
+          C.CONCATEGORY_API + allCategors[idx].id + C.NESTED
+        );
+        setPH([...APIdata.conCategory1.conCategory2s]);
+      }
+    })();
+  }, []);
+  useEffect(() => {
+    setBrandsList([...brandsList, ...PH]);
+    const propsidx = brandsList.findIndex(e => e.id === parseInt(curruntID));
+    const temp = propsidx !== -1 ? brandsList[propsidx].conItems : [];
+    setbrandProductList(temp);
+  }, [PH]);
+  interface productType {
+    id: string;
+  }
+  useEffect(() => {
+    brandProductList.forEach(async (product: productType) => {
+      const APIdata = await H.Fetch(C.CONITEM_API + product.id);
+      setproductInfo(APIdata);
+    });
+  }, [brandProductList]);
+  useEffect(() => {
+    if (productInfo.conItem) {
+      const newstate: any = containerProps;
+      newstate.push(productInfo.conItem);
+      setContainerProps(newstate);
+    }
+  }, [productInfo]);
+  return (
+    <>
+      <NavBar
+        brandName={
+          containerProps[0] ? containerProps[0].conCategory2.name : undefined
+        }
+      />
       <div className={styles.container}>
         <main className={styles.main}>
-          <div className='warpper'>
-            {containerProps.length < 10? <div className="ProductStock"><span className='stock'>{`0${containerProps.length}`}</span>개의 상품</div>
-            :<div className="ProductStock"><span className='stock'>{containerProps.length}</span >개의 상품</div>
-            }
+          <div className="warpper">
+            {containerProps.length < 10 ? (
+              <div className="ProductStock">
+                <span className="stock">{`0${containerProps.length}`}</span>개의
+                상품
+              </div>
+            ) : (
+              <div className="ProductStock">
+                <span className="stock">{containerProps.length}</span>개의 상품
+              </div>
+            )}
           </div>
-          <ProductContainer ProductData = {containerProps} isItemList = {true}/>
+          <ProductContainer ProductData={containerProps} isItemList={true} />
         </main>
-        <footer className={styles.footer}>
-          
-        </footer>
+        <footer className={styles.footer}></footer>
         <style jsx>{`
           .warpper{
             width: 100%;
@@ -75,7 +98,6 @@ const Brands = ({ allCategors, currentPage, curruntID, BrandList }: PropsType) =
             display: flex;
             background-color: #fff;
           }
-
           .ProductStock{
             flex-grow: 1;
             align-self: center;
@@ -93,25 +115,24 @@ const Brands = ({ allCategors, currentPage, curruntID, BrandList }: PropsType) =
           }
         `}</style>
       </div>
-      </>
-      
-    )
-  }
-  
-export const getServerSideProps: GetServerSideProps = async (context:GetServerSidePropsContext) => {
-  const curruntID = context.params? context.params.id: undefined;
+    </>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps = async (
+  context: GetServerSidePropsContext
+) => {
+  const curruntID = context.params ? context.params.id : undefined;
   let allCategors = await H.Fetch(C.CONCATEGORY_API);
   allCategors = allCategors.conCategory1s;
- 
 
   return {
     props: {
-        allCategors: allCategors,
-        currentPage: 'brands',
-        curruntID: curruntID,
+      allCategors: allCategors,
+      currentPage: 'brands',
+      curruntID: curruntID,
     },
   };
 };
 
-
-  export default Brands
+export default Brands;

--- a/pages/categories/[id].tsx
+++ b/pages/categories/[id].tsx
@@ -1,54 +1,85 @@
-import type { NextPage, GetServerSideProps, GetServerSidePropsContext } from 'next'
-import { useRouter } from 'next/router'
-import styles from 'styles/Categories.module.css'
-import * as C from "Const/Const";
-import * as H from "Hooks/Hooks";
-import { useState, useEffect } from 'react';
+import type {
+  NextPage,
+  GetStaticProps,
+  GetStaticPropsContext,
+  GetStaticPaths,
+} from 'next';
+import { useRouter } from 'next/router';
+import styles from 'styles/Categories.module.css';
+import * as T from 'Types/Types';
+import * as C from 'Const/Const';
+import * as H from 'Hooks/Hooks';
+import { useState, useEffect, useCallback } from 'react';
 import CategoryContainer from 'Components/CategoryContainer/index.CategoryContainer';
 import ProductContainer from 'Components/ProductContainer/index.ProductContainer';
 import NavBar from 'Components/Nav/NavBar';
+import { ProductProps } from 'Components/Types/ProductType';
 
 interface CategoriesProps {
-  currentPage: string,
-  curruntID: string,
-  categoryProps: any,
-  category1Props: any[]
+  currentPage: string;
+  curruntID: string;
+  categoryProps: any;
 }
 
-const Categories: NextPage<CategoriesProps> = ({currentPage, curruntID, categoryProps, category1Props}) => {
-    const router = useRouter();
-    return (
-      <>
-      <NavBar/>
+const Categories: NextPage<CategoriesProps> = ({
+  currentPage,
+  curruntID,
+  categoryProps,
+}) => {
+  const [category1Props, setCategory1Props] = useState<
+    ProductProps[] | undefined
+  >();
+  const FetchProductContent = useCallback(async () => {
+    const res = await H.Fetch(`${C.CONITEM_API}/${C.SOON}`);
+    setCategory1Props(
+      res.conItems.sort((a: { id: number }, b: { id: number }) => a.id - b.id)
+    );
+  }, []);
+  useEffect(() => {
+    FetchProductContent();
+  }, [FetchProductContent]);
+  return (
+    <>
+      <NavBar />
       <div className={styles.container}>
         <main className={styles.main}>
-          {curruntID !== "1"?
-          <CategoryContainer CategoryData={categoryProps} currentPage={currentPage}/>
-          :
-          <ProductContainer ProductData = {category1Props}/>
-        }
+          {curruntID !== '1' ? (
+            <CategoryContainer
+              CategoryData={categoryProps}
+              currentPage={currentPage}
+            />
+          ) : (
+            <ProductContainer ProductData={category1Props} />
+          )}
         </main>
-        <footer className={styles.footer}>
-          
-        </footer>
+        <footer className={styles.footer}></footer>
       </div>
-      </>
-    )
-  }
-  
-export const getServerSideProps: GetServerSideProps = async (context:GetServerSidePropsContext) => {
-  const curruntID = context.params? context.params.id: undefined;
+    </>
+  );
+};
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const pathList = ['1', '67', '62', '60', '61', '65', '129', '69', '128'];
+  const paths = pathList.map((categoryItem: any) => ({
+    params: { id: categoryItem.toString() },
+  }));
+  return {
+    paths,
+    fallback: false,
+  };
+};
+export const getStaticProps: GetStaticProps = async (
+  context: GetStaticPropsContext
+) => {
+  const curruntID = context.params ? context.params.id : undefined;
   const categoryProps = await H.Fetch(C.CONCATEGORY_API + curruntID + C.NESTED);
-  const category1Props = await H.Fetch(C.CONITEM_API + C.SOON);
   return {
     props: {
       currentPage: 'categories',
       curruntID: curruntID,
       categoryProps: categoryProps.conCategory1.conCategory2s,
-      category1Props: category1Props.conItems.sort((a: { id: number; }, b: { id: number; })=> a.id - b.id)
     },
   };
 };
 
-
-  export default Categories
+export default Categories;

--- a/pages/contacts.tsx
+++ b/pages/contacts.tsx
@@ -1,28 +1,28 @@
-import QuestionContainer from "Components/QuestionContainer/index.QuestionContainer";
-import styles from "styles/Home.module.css";
-import CustomerStyle from "styles/CustomerCenter.module.css";
+import QuestionContainer from 'Components/QuestionContainer/index.QuestionContainer';
+import styles from 'styles/Home.module.css';
+import CustomerStyle from 'styles/CustomerCenter.module.css';
 
-import * as H from "Hooks/Hooks";
-import * as C from "Const/Const";
-import * as T from "Types/Types";
+import * as H from 'Hooks/Hooks';
+import * as C from 'Const/Const';
+import * as T from 'Types/Types';
 
-import { NextPage, GetServerSideProps } from "next";
-import NavBar from "Components/Nav/NavBar";
+import { NextPage, GetStaticProps } from 'next';
+import NavBar from 'Components/Nav/NavBar';
 
 const CustomerCenter: NextPage<T.CustomerCenterProps> = ({ faqType }) => {
   return (
     <>
-    <NavBar/>
-    <div className={CustomerStyle.container}>
-      <main className={CustomerStyle.main}>
+      <NavBar />
+      <div className={CustomerStyle.container}>
+        <main className={CustomerStyle.main}>
           <QuestionContainer faqType={faqType} />
-      </main>
-    </div>
+        </main>
+      </div>
     </>
   );
 };
 
-export const getServerSideProps: GetServerSideProps = async () => {
+export const getStaticProps: GetStaticProps = async () => {
   const faqType = await H.Fetch(C.FAQTYPE_API);
   return {
     props: {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -29,7 +29,6 @@ const Home: NextPage<HomeProps> = ({ currentPage, menuCategory }) => {
   useEffect(() => {
     FetchProductContent();
   }, [FetchProductContent]);
-  console.log(productContent);
   return (
     <>
       <NavBar />

--- a/pages/items/[id].tsx
+++ b/pages/items/[id].tsx
@@ -1,52 +1,42 @@
-import { GetServerSideProps, GetServerSidePropsContext } from "next";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from 'react';
 
-import * as H from "Hooks/Hooks";
-import * as C from "Const/Const";
-import * as T from "Types/Types";
+import * as H from 'Hooks/Hooks';
+import * as C from 'Const/Const';
+import * as T from 'Types/Types';
 
-import styles from "styles/Item.module.css";
-import ItemContainer from "Components/ItemContainer/index.ItemContainer";
-
+import styles from 'styles/Item.module.css';
+import ItemContainer from 'Components/ItemContainer/index.ItemContainer';
+import { useRouter } from 'next/router';
 import NavBar from 'Components/Nav/NavBar';
 
-interface ItemPageProps {
-  currentId: number;
-}
-
-const Items = ({ currentId }:ItemPageProps) => {
+const Items = () => {
   const [itemData, setItemData] = useState<T.ItemProps>();
-
+  const router = useRouter();
+  const [currentId, setCurrentId] = useState<number>();
+  const FetchItemData = useCallback(async () => {
+    const res = await H.Fetch(`${C.CONITEM_API}/${currentId}`);
+    setItemData(res.conItem);
+  }, [currentId]);
   useEffect(() => {
-    (async () => {
-      const res = await H.Fetch(`${C.CONITEM_API}/${currentId}`);
-      setItemData(res.conItem);
-    })();
-  }, []);
+    if (router.query.id && typeof router.query.id !== 'object') {
+      setCurrentId(parseInt(router.query.id));
+      if (currentId !== undefined) {
+        FetchItemData();
+      }
+    }
+  }, [FetchItemData, currentId, router.query.id]);
 
   return (
     <>
-    <NavBar/>
-    <div className={styles.container}>
-      <main className={styles.main}>
+      <NavBar />
+      <div className={styles.container}>
+        <main className={styles.main}>
           {itemData && <ItemContainer itemData={itemData} />}
-      </main>
-      <footer className={styles.footer}></footer>
-    </div>
+        </main>
+        <footer className={styles.footer}></footer>
+      </div>
     </>
   );
-};
-
-export const getServerSideProps: GetServerSideProps = async (
-  context: GetServerSidePropsContext
-) => {
-  const currentId = context.params ? context.params.id : undefined;
-
-  return {
-    props: {
-      currentId: currentId,
-    },
-  };
 };
 
 export default Items;


### PR DESCRIPTION
 ### pages/categories/[id].tsx 
- 기존 렌더링 방식 : 사전 렌더링(getServerSideProps 함수를 사용한 SSR)
- 변경된 렌더링 방식 : 사전렌더링(getStaticProps와 getStaticPaths 함수를 사용한 dynamic SSG)
  -  변경 이유: 카테고리 별 브랜드목록은 매번 바뀌지 않습니다.
  -  getStaticPaths에 라우팅되는 경우의 수를 추가하였습니다.

 ### pages/contacts
- 기존 렌더링 방식 : 사전 렌더링(getServerSideProps 함수를 사용한 SSR)
- 변경된 렌더링 방식 : 사전 렌더링(getStaticProps 함수를 사용한 SSR)
  - 변경 이유 : 고객센터 페이지는 빌드 시점마다 변하지 않습니다.

### pages/categories/[id].tsx 
- 기존 렌더링 방식 : 사전 렌더링(getServerSideProps 함수를 사용한 SSR)
- 변경된 렌더링 방식 : CSR
  - 변경 이유 : 아이템 목록, 할인율 등은 수시로 바뀌기 때문에 CSR를 사용하였습니다.