### PR TITLE
Fix: NavBar 뒤로가기 버튼 조건 추가

### DIFF
--- a/Components/Nav/NavBar.tsx
+++ b/Components/Nav/NavBar.tsx
@@ -43,8 +43,8 @@ const NavBar = ({ brandName }: propsTypes): JSX.Element => {
       }
     })();
   }, []);
-
   const routerPath = useRouter().asPath;
+  let path = routerPath.split('/');
   useEffect(() => {
     setSelected(Number(routerPath.replace(/[^0-9]/g, '')));
   }, [routerPath]);
@@ -81,6 +81,17 @@ const NavBar = ({ brandName }: propsTypes): JSX.Element => {
                       alt="seeback"
                       width="20px"
                       height="20px"
+                    />
+                  </div>
+                </Link>
+              ) : path[1] === 'categories' ? (
+                <Link href="/" passHref>
+                  <div className={style.navImage}>
+                    <Image
+                      src="/images/arrowback.png"
+                      alt="seeback"
+                      width="30px"
+                      height="30px"
                     />
                   </div>
                 </Link>


### PR DESCRIPTION
categories 안에서 동적 라우팅이 일어날 때 뒤로가기 버튼을 누르면 메인 페이지가 아닌 이전 카테고리로 이동하는 문제가 발생했습니다.

```
const routerPath = useRouter().asPath;
let path = routerPath.split('/'); //조건을 위해 추가된 코드
```
여기서 path[1]이 categories인 경우 메인 페이지로 이동하도록 조건을 추가했습니다.